### PR TITLE
fix: update navbar sticky position to display outlet content

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -15,7 +15,7 @@ export function Navbar() {
 	};
 
 	return (
-		<nav className="fixed top-0 right-0 left-0 z-50 bg-primary-black shadow-lg">
+		<nav className="sticky top-0 right-0 left-0 z-50 bg-primary-black shadow-lg">
 			<div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
 				<div className="flex items-center justify-between py-6">
 					<Link className="flex gap-2" to="/">


### PR DESCRIPTION
- fix: update navbar sticky position to display outlet content

This pull request includes a small change to the `Navbar` component in `src/components/navbar.tsx`. The change modifies the `nav` element's position from `fixed` to `sticky`, ensuring it behaves differently in relation to scrolling.